### PR TITLE
Fixed string parameter issue, 0.3.2

### DIFF
--- a/Decos.Fixi.Tests/IssuesApiTests.cs
+++ b/Decos.Fixi.Tests/IssuesApiTests.cs
@@ -208,6 +208,15 @@ namespace Decos.Fixi.Tests
     }
 
     [TestMethod]
+    public async Task NoIssuesAreReturnedWhenSearchingOnRandomGuid()
+    {
+      var searchString = $"{Guid.NewGuid()}";
+      var issues = await FixiClient.Issues.FindAsync(q: searchString);
+
+      Assert.AreEqual(0, issues.Count);
+    }
+
+    [TestMethod]
     public async Task SomeIssuesHaveUserDetails()
     {
       var issues = await FixiClient.Issues.FindAsync();

--- a/Decos.Fixi.Tests/QueryStringParameterCollectionTests.cs
+++ b/Decos.Fixi.Tests/QueryStringParameterCollectionTests.cs
@@ -80,6 +80,16 @@ namespace Decos.Fixi.Tests
     }
 
     [TestMethod]
+    public void QueryStringParameterCollectionDoesNotInterpretStringsAsACollectionOfCharacters()
+    {
+      const string value = "12345";
+      var collection = QueryStringParameterCollection.FromObject(new { a = value });
+
+      var result = collection.Collection.GetValues("a");
+      CollectionAssert.AreEquivalent(new string[1] { value }, result);
+    }
+
+    [TestMethod]
     public void QueryStringParameterCollectionAddsMultipleValuesForEnumerableTypes()
     {
       var collection = new QueryStringParameterCollection();

--- a/Decos.Fixi/Decos.Fixi.nuspec
+++ b/Decos.Fixi/Decos.Fixi.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/DecosInformationSolutions/FixiClient-dotnet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Fixi API client library for .NET</description>
-    <releaseNotes>Added missing "User" property and ever-so-slightly improved exception handling.</releaseNotes>
+    <releaseNotes>Fixed issue where string parameters added a query string parameter for every character in the string.</releaseNotes>
     <copyright>Copyright 2017</copyright>
     <tags>Decos JOIN Fixi Client</tags>
   </metadata>

--- a/Decos.Fixi/Http/QueryStringParameterCollection.cs
+++ b/Decos.Fixi/Http/QueryStringParameterCollection.cs
@@ -130,6 +130,9 @@ namespace Decos.Fixi.Http
     /// <param name="value">The value of the entry to add.</param>
     public QueryStringParameterCollection Add(string name, object value)
     {
+      if (value is string)
+        return Add(name, (string)value);
+
       Add(name, value, CultureInfo.InvariantCulture);
       return this;
     }
@@ -149,7 +152,7 @@ namespace Decos.Fixi.Http
     /// </remarks>
     public virtual QueryStringParameterCollection Add(string name, object value, IFormatProvider provider)
     {
-      if (value is IEnumerable)
+      if (value is IEnumerable && !(value is string))
       {
         foreach (var item in (IEnumerable)value)
           Add(name, Convert.ToString(item, provider));

--- a/Decos.Fixi/Properties/AssemblyInfo.cs
+++ b/Decos.Fixi/Properties/AssemblyInfo.cs
@@ -28,7 +28,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision
 // Numbers by using the '*' as shown below: [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.3.1.0")]
-[assembly: AssemblyFileVersion("0.3.1.0")]
-[assembly: AssemblyInformationalVersion("0.3.1")]
+[assembly: AssemblyVersion("0.3.2.0")]
+[assembly: AssemblyFileVersion("0.3.2.0")]
+[assembly: AssemblyInformationalVersion("0.3.2")]
 [assembly: InternalsVisibleTo("Decos.Fixi.Tests")]


### PR DESCRIPTION
- Fixed an issue where string parameters were incorrectly treated as `IEnumerable<char>` and would cause multiple query string parameters for each character (`?q=123` vs `?q=1&a=2&q=3`)